### PR TITLE
Make class of Item

### DIFF
--- a/src/org/newdawn/spaceinvaders/Game.java
+++ b/src/org/newdawn/spaceinvaders/Game.java
@@ -270,6 +270,16 @@ public class Game extends Canvas
 			shotplayer.playShotSound("src/sound/shot.wav");
 		}).start();
 	}
+
+	//implement setter of moveSpeed for Item.increaseMoveSpeed
+	public void increaseMoveSpeed(){
+		this.moveSpeed *= 1.5;
+	}
+
+	//implement setter of firingInterval for Item.increaseFireSpeed
+	public void increaseFireSpeed(){
+		this.firingInterval = 150;
+	}
 	
 	/**
 	 * The main game loop. This loop is running during all game
@@ -282,6 +292,7 @@ public class Game extends Canvas
 	 * - Checking Input
 	 * <p>
 	 */ // 게임 메인 루프 -> 플레이 중 활동
+
 	public void gameLoop() {
 
 		long lastLoopTime = SystemTimer.getTime();

--- a/src/org/newdawn/spaceinvaders/Item.java
+++ b/src/org/newdawn/spaceinvaders/Item.java
@@ -1,0 +1,49 @@
+package org.newdawn.spaceinvaders;
+
+import org.newdawn.spaceinvaders.entity.ShipEntity;
+import org.newdawn.spaceinvaders.Game;
+
+import java.awt.Graphics;
+import java.util.ArrayList;
+
+public class Item {
+    private Boolean[] itemList = new Boolean[] {false, false, false, false, false};
+    private Game game;
+
+    public Item(Game g){
+        this.game = g;
+    }
+
+    public void clearStage(int stage){
+        this.itemList[stage] = true;
+    }
+
+    public void increaseFireSpeed(){
+        if(this.itemList[0] == true){ this.game.increaseFireSpeed(); }
+        else{ showUnableMessage(); }
+    }
+
+    public void increaseMaxHealth(){
+        if(this.itemList[1] == true){}
+        else{ showUnableMessage(); }
+    }
+
+    public void increaseMoveSpeed(){
+        if (this.itemList[2] == true){ this.game.increaseMoveSpeed(); }
+        else{ showUnableMessage(); }
+    }
+
+    public void equipShiled(){
+        if (this.itemList[3] == true){}
+        else{ showUnableMessage(); }
+    }
+
+    public void increaseFireNum(){
+        if (this.itemList[4] == true){}
+        else{ showUnableMessage(); }
+    }
+
+    private void showUnableMessage(){
+        /*Need to implement drawString("You didn't clear stage yet.")*/ 
+    }
+}


### PR DESCRIPTION
Item class 구현, itemList를 통해 클리어한 stage의 index에 해당하는 값이 true로 바뀜
각 아이템 기능을 활성화할 때 itemList의 boolean값을 확인하여 활성화
increaseFireSpeed와 increaseMoveSpeed는 추가 기능이 없는 코드에서도 추가 가능하므로 Game class의 setter를 통해 조작하도록 함, 나머지 아이템은 차후 property가 추가될경우 해당 property에 대한 setter 구현을 통해 할 예정
showUnableMessage의 경우 Game class 내에서 어떻게 drawString을 구현해야할지 몰라 주석으로 처리

해당 class에 대한 debugging이 진행되지 않았기 때문에 정상작동을 장담할 수 없고 개발 방향에 따라 내부 코드가 완전히 바뀔 수 있음. 현재로써 가능하다고 생각되는 방식의 예시를 코드로 구현한 것